### PR TITLE
Make mouse wheel acceleration work again

### DIFF
--- a/DiscreteScroll/main.m
+++ b/DiscreteScroll/main.m
@@ -8,8 +8,10 @@ CGEventRef cgEventCallback(CGEventTapProxy proxy, CGEventType type,
 {
     if (!CGEventGetIntegerValueField(event, kCGScrollWheelEventIsContinuous)) {
         int64_t delta = CGEventGetIntegerValueField(event, kCGScrollWheelEventPointDeltaAxis1);
+        int64_t sign = SIGN(delta);
+        if (delta * sign < LINES) delta = sign * LINES; // clamp scrolling magnitude to a minimum
         
-        CGEventSetIntegerValueField(event, kCGScrollWheelEventDeltaAxis1, SIGN(delta) * LINES);
+        CGEventSetIntegerValueField(event, kCGScrollWheelEventDeltaAxis1, delta);
     }
     
     return event;


### PR DESCRIPTION
Maybe it's a matter of preference, but I like mouse wheel acceleration, especially when I need to scroll through long documents. So I made this great program only scale up the scroll values which are too small and leave the larger ones alone. It feels very good to me.