### PR TITLE
Update README Installation instructions for newer versions of macOS

### DIFF
--- a/DiscreteScroll.xcodeproj/project.pbxproj
+++ b/DiscreteScroll.xcodeproj/project.pbxproj
@@ -7,13 +7,13 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		C32391431DE7B5670068C5B9 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = C32391421DE7B5670068C5B9 /* main.m */; };
+		C32391431DE7B5670068C5B9 /* main.c in Sources */ = {isa = PBXBuildFile; fileRef = C32391421DE7B5670068C5B9 /* main.c */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
 		C323913A1DE7B5670068C5B9 /* DiscreteScroll.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = DiscreteScroll.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		C323913E1DE7B5670068C5B9 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		C32391421DE7B5670068C5B9 /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
+		C32391421DE7B5670068C5B9 /* main.c */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.c; path = main.c; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -46,7 +46,7 @@
 		C323913C1DE7B5670068C5B9 /* DiscreteScroll */ = {
 			isa = PBXGroup;
 			children = (
-				C32391421DE7B5670068C5B9 /* main.m */,
+				C32391421DE7B5670068C5B9 /* main.c */,
 				C323913E1DE7B5670068C5B9 /* Info.plist */,
 			);
 			path = DiscreteScroll;
@@ -119,7 +119,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				C32391431DE7B5670068C5B9 /* main.m in Sources */,
+				C32391431DE7B5670068C5B9 /* main.c in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/DiscreteScroll.xcodeproj/project.pbxproj
+++ b/DiscreteScroll.xcodeproj/project.pbxproj
@@ -88,7 +88,7 @@
 			};
 			buildConfigurationList = C32391351DE7B5670068C5B9 /* Build configuration list for PBXProject "DiscreteScroll" */;
 			compatibilityVersion = "Xcode 3.2";
-			developmentRegion = English;
+			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				en,
@@ -243,6 +243,7 @@
 				C32391591DE7B5670068C5B9 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
 	};

--- a/DiscreteScroll.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/DiscreteScroll.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/DiscreteScroll/Info.plist
+++ b/DiscreteScroll/Info.plist
@@ -17,11 +17,11 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>0.1.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>1</string>
+	<string>0.1.1</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
 	<key>LSUIElement</key>

--- a/DiscreteScroll/main.c
+++ b/DiscreteScroll/main.c
@@ -1,4 +1,4 @@
-#import <ApplicationServices/ApplicationServices.h>
+#include <ApplicationServices/ApplicationServices.h>
 
 #define SIGN(x) (((x) > 0) - ((x) < 0))
 #define LINES 3

--- a/DiscreteScroll/main.m
+++ b/DiscreteScroll/main.m
@@ -3,15 +3,14 @@
 #define SIGN(x) (((x) > 0) - ((x) < 0))
 #define LINES 3
 
-CGEventRef cgEventCallback(CGEventTapProxy proxy, CGEventType type,
-                           CGEventRef event, void *refcon)
+CGEventRef cgEventCallback(CGEventTapProxy proxy, CGEventType type, CGEventRef event, void *refcon)
 {
     if (!CGEventGetIntegerValueField(event, kCGScrollWheelEventIsContinuous)) {
         int64_t delta = CGEventGetIntegerValueField(event, kCGScrollWheelEventPointDeltaAxis1);
-        
+
         CGEventSetIntegerValueField(event, kCGScrollWheelEventDeltaAxis1, SIGN(delta) * LINES);
     }
-    
+
     return event;
 }
 
@@ -19,17 +18,16 @@ int main(void)
 {
     CFMachPortRef eventTap;
     CFRunLoopSourceRef runLoopSource;
-    
-    eventTap = CGEventTapCreate(kCGSessionEventTap, kCGHeadInsertEventTap, 0,
-                                1 << kCGEventScrollWheel, cgEventCallback, NULL);
+
+    eventTap = CGEventTapCreate(kCGSessionEventTap, kCGHeadInsertEventTap, 0, 1 << kCGEventScrollWheel, cgEventCallback, NULL);
     runLoopSource = CFMachPortCreateRunLoopSource(kCFAllocatorDefault, eventTap, 0);
-    
+
     CFRunLoopAddSource(CFRunLoopGetCurrent(), runLoopSource, kCFRunLoopCommonModes);
     CGEventTapEnable(eventTap, true);
     CFRunLoopRun();
-    
+
     CFRelease(eventTap);
     CFRelease(runLoopSource);
-    
+
     return 0;
 }

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Fix for macOS's unnecessary scroll acceleration
 
 ## Supported versions
 
-As of 2021, this fix works on all the recent macOS versions, specifically 10.9–11.
+As of October 2023, this fix works on macOS versions 10.9–14.0.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ As of 2021, this fix works on all the recent macOS versions, specifically 10.9â€
 ## Installation
 
 You may download the binary
-[here](https://github.com/emreyolcu/discrete-scroll/releases/download/v0.1.1/DiscreteScroll.zip). It
+[here](https://github.com/emreyolcu/discrete-scroll/releases/download/v0.1.1u/DiscreteScroll.zip). It
 runs in the background and allows you to scroll 3 lines with each tick of the
 wheel.
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,12 @@ You may download the binary
 runs in the background and allows you to scroll 3 lines with each tick of the
 wheel.
 
-It needs to be run each time you boot. If you want this to be automatic you
-may go to `System Preferences > Users & Groups > Login Items` and add
-`DiscreteScroll` to the list. If you want to undo the effect you may launch
+It needs to be run each time you boot. If you want this to be automatic you may add `DiscreteScroll` to the list of Login Items that are opened automatically.
+
+* macOS 13 and later:   `System Settings > General > Login Items` and add
+`DiscreteScroll` to the list.
+* macOS 12 and earlier:  `System Preferences > Users & Groups > Login Items` and add
+`DiscreteScroll` to the list.
+
+If you want to undo the effect you may launch
 Activity Monitor, search for `DiscreteScroll` and force it to quit.


### PR DESCRIPTION
The macOS menu for setting Login Items changed since macOS 13. This commit includes the menu setting paths for each. Before this change, the instructions reference the macOS 12 and earlier settings.